### PR TITLE
Feat/local calculations

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
       VAULT_ADDRESS: "${VAULT_ADDRESS}"
       POSITION_MANAGER_ADDRESS: "${POSITION_MANAGER_ADDRESS}"
       INTERVAL_MS: "${INTERVAL_MS}"
+      MAX_LEVERAGE_BPS: "${MAX_LEVERAGE_BPS}"
     links:
       - mongo
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "ethers": "^5.4.4",
         "express": "^4.17.1",
         "mongoose": "^6.3.6",
+        "node-cache": "^5.1.2",
         "node-cron": "3.0.0",
         "nodemon": "^2.0.16",
         "prom-client": "^14.0.1",

--- a/src/helpers/getPositionsToLiquidate.ts
+++ b/src/helpers/getPositionsToLiquidate.ts
@@ -10,7 +10,6 @@ const getPositionsToLiquidate = async (vault: Vault, openPositions: IPositionSch
 
     const positionsOverMaxLeverage: IPositionSchema[] = [];
     for (const position of openPositions) {
-        console.log(`Checking position ${position.key}`);
         const size = BigNumber.from(position.size);
         const liquidationMargin = size.mul(basisPointsDivisor).div(maxLeverageBps);
 
@@ -19,14 +18,7 @@ const getPositionsToLiquidate = async (vault: Vault, openPositions: IPositionSch
         const collateral = BigNumber.from(position.collateralAmount);
         const delta = getDelta(position, price);
         const remainingCollateral = collateral.add(delta);
-
-
-        console.log(`Remaining collateral: ${ethers.utils.formatUnits(remainingCollateral, 30)}`);
-        console.log(`Size: ${ethers.utils.formatUnits(size, 30)}`);
-        console.log(`Price: ${ethers.utils.formatUnits(price, 30)}`);
-        console.log(`Delta: ${ethers.utils.formatUnits(delta, 30)}`);
-        console.log(`Liquidation margin: ${ethers.utils.formatUnits(liquidationMargin, 30)}`);
-
+        
         if (remainingCollateral.lte(liquidationMargin)) {
             positionsOverMaxLeverage.push(position);
         }

--- a/src/helpers/getPositionsToLiquidate.ts
+++ b/src/helpers/getPositionsToLiquidate.ts
@@ -1,33 +1,52 @@
 import { IPositionSchema } from "src/models/position";
 import { Vault } from "@mycelium-ethereum/perpetual-swaps-contracts";
-
+import Cache from "node-cache";
 import { retry } from "./helpers";
 import { BigNumber, ethers } from "ethers";
 
 const getPositionsToLiquidate = async (vault: Vault, openPositions: IPositionSchema[]) => {
-    const maxLeverageBps = await vault.maxLeverage();
+    const maxLeverageBps = process.env.MAX_LEVERAGE_BPS ? BigNumber.from(process.env.MAX_LEVERAGE_BPS) : BigNumber.from(500000);
     const basisPointsDivisor = 10000;
 
-    const promises = openPositions.map(async (position) => {
-        const price = await getTokenPrice(position.indexToken, position.isLong, vault);
-        const margin = getMargin(position, price);
+    const positionsOverMaxLeverage: IPositionSchema[] = [];
+    for (const position of openPositions) {
+        console.log(`Checking position ${position.key}`);
         const size = BigNumber.from(position.size);
+        const liquidationMargin = size.mul(basisPointsDivisor).div(maxLeverageBps);
 
-        const shouldLiquidate = margin.mul(maxLeverageBps).lt(size.mul(basisPointsDivisor));
 
-        if (shouldLiquidate) {
-            // Confirm that the position is liquidatible
-            const liquidationState = await getLiquidationState(position, vault);
-            if (liquidationState > 0) {
-                console.log("ToLiquidatePosition******************************");
-                console.log(`LiquidationState: ${liquidationState}`);
-                console.log(position);
-                return position;
-            }
+        const price = await getTokenPrice(position.indexToken, position.isLong, vault);
+        const collateral = BigNumber.from(position.collateralAmount);
+        const delta = getDelta(position, price);
+        const remainingCollateral = collateral.add(delta);
+
+
+        console.log(`Remaining collateral: ${ethers.utils.formatUnits(remainingCollateral, 30)}`);
+        console.log(`Size: ${ethers.utils.formatUnits(size, 30)}`);
+        console.log(`Price: ${ethers.utils.formatUnits(price, 30)}`);
+        console.log(`Delta: ${ethers.utils.formatUnits(delta, 30)}`);
+        console.log(`Liquidation margin: ${ethers.utils.formatUnits(liquidationMargin, 30)}`);
+
+        if (remainingCollateral.lte(liquidationMargin)) {
+            positionsOverMaxLeverage.push(position);
         }
-    });
-    const positionsToLiquidate = await Promise.all(promises);
-    return positionsToLiquidate.filter(Boolean);
+    }
+
+    console.log(`Positions over max leverage: ${positionsOverMaxLeverage.length}`);
+
+    // Confirm in contract that position is liquidatible
+    const positionsToLiquidate: IPositionSchema[] = [];
+    await Promise.all(positionsOverMaxLeverage.map(async (position) => {
+        const liquidationState = await getLiquidationState(position, vault);
+        if (liquidationState > 0) {
+            console.log("ToLiquidatePosition******************************");
+            console.log(`LiquidationState: ${liquidationState}`);
+            console.log(position);
+            positionsToLiquidate.push(position);
+        }
+    }));
+
+    return positionsToLiquidate;
 };
 
 const getPositionExists = async (dbPosition: IPositionSchema, vault: Vault) => {
@@ -74,42 +93,36 @@ const getLiquidationState = async (dbPosition: IPositionSchema, vault: Vault) =>
             timeoutSeconds: 5,
         });
 
+        if (!liquidationState) return 0;
         return liquidationState.toNumber();
     } catch (err) {
         console.error(err);
     }
 };
 
-type PriceCache = {
-    [key: string]: {
-        value: BigNumber;
-        timestamp: number;
-    };
-};
-const priceCache: PriceCache = {};
+const INTERVAL = process.env.INTERVAL_MS ? parseInt(process.env.INTERVAL_MS) : 60000;
+const priceCache = new Cache({ stdTTL: INTERVAL / 1000 });
 const getTokenPrice = async (address: string, isLong: boolean, vault: Vault) => {
     const key = `${address}-${isLong}`;
-    const cacheExpiry = 60 * 1000; // 1 minute
-    if (priceCache[key] && priceCache[key].timestamp + cacheExpiry < Date.now()) {
-        return priceCache[key].value;
+    const cachedPrice = priceCache.get(key) as BigNumber | undefined;
+    if (cachedPrice) {
+        return cachedPrice;
     } else {
+        console.log("Fetching new price for " + key);
         const price = isLong ? await vault.getMinPrice(address) : await vault.getMaxPrice(address);
-        priceCache[key] = {
-            value: price,
-            timestamp: Date.now(),
-        };
+        priceCache.set(key, price);
         return price;
     }
 };
 
-const getMargin = (position: IPositionSchema, price: BigNumber) => {
+const getDelta = (position: IPositionSchema, price: BigNumber) => {
     const collateral = BigNumber.from(position.collateralAmount);
     const size = BigNumber.from(position.size);
     const averagePrice = BigNumber.from(position.averagePrice);
     const priceDelta = position.isLong ? price.sub(averagePrice) : averagePrice.sub(price);
-
     const delta = size.mul(priceDelta).div(averagePrice);
-    return collateral.add(delta);
+
+    return delta;
 };
 
 export default getPositionsToLiquidate;

--- a/src/helpers/liquidatePositions.ts
+++ b/src/helpers/liquidatePositions.ts
@@ -1,18 +1,19 @@
 import { IPositionSchema } from "../models/position";
-import colors from 'colors';
+import colors from "colors";
 import { PositionManager } from "@mycelium-ethereum/perpetual-swaps-contracts";
 import { liquidations } from "../utils/prometheus";
+import { ethers } from "ethers";
 
 export const liquidateInBatches = async (positions: IPositionSchema[], positionManager: PositionManager) => {
     let cursor = 0;
     const positionsPerTransaction = 50;
     while (cursor < positions.length) {
         const batchPositions = positions.slice(cursor, cursor + positionsPerTransaction);
+
         if (batchPositions.length === 1) {
-            // If there is only one position, sometimes the batch transaction doesn't work for some reason
-            // so we just send it separately
-            console.log(colors.yellow(`Liquidating ${batchPositions.length} position`));
+            console.log(`Liquidating ${batchPositions.length} position`);
             const position = batchPositions[0];
+
             const tx = await positionManager.liquidatePosition(
                 position.account,
                 position.collateralToken,
@@ -20,14 +21,23 @@ export const liquidateInBatches = async (positions: IPositionSchema[], positionM
                 position.isLong,
                 process.env.FEE_RECEIVER_ADDRESS
             );
+
             const receipt = await tx.wait();
-            console.log(colors.green(`Sent!`));
-            console.log(colors.green(`Transaction receipt: ${receipt.transactionHash}`));
+
+            console.log(colors.green(`Liquidated position ${position.key}`));
+            console.log(colors.green(`Transaction hash: ${receipt.transactionHash}`));
         } else {
             const accounts = batchPositions.map((position) => position.account);
             const collateralTokens = batchPositions.map((position) => position.collateralToken);
             const indexTokens = batchPositions.map((position) => position.indexToken);
             const isLongs = batchPositions.map((position) => position.isLong);
+
+            // For some reason, the last position in the batch is not liquidated
+            // so we add a null value to the end of the arrays to fix this
+            accounts.push(ethers.constants.AddressZero);
+            collateralTokens.push(ethers.constants.AddressZero);
+            indexTokens.push(ethers.constants.AddressZero);
+            isLongs.push(false);
 
             console.log(colors.yellow(`Liquidating positions ${cursor} to ${cursor + batchPositions.length}...`));
             const tx = await positionManager.liquidatePositions(
@@ -37,16 +47,16 @@ export const liquidateInBatches = async (positions: IPositionSchema[], positionM
                 isLongs,
                 process.env.FEE_RECEIVER_ADDRESS
             );
+
             const receipt = await tx.wait();
 
             console.log(colors.green(`Sent!`));
             console.log(colors.green(`Transaction hash: ${receipt.transactionHash}`));
         }
-
         liquidations.inc(batchPositions.length);
         cursor += positionsPerTransaction;
     }
-}
+};
 
 export const liquidateOneByOne = async (positions: IPositionSchema[], positionManager: PositionManager) => {
     for (const position of positions) {
@@ -63,4 +73,4 @@ export const liquidateOneByOne = async (positions: IPositionSchema[], positionMa
         console.log(colors.green(`Transaction hash: ${receipt.transactionHash}`));
         liquidations.inc(1);
     }
-}
+};

--- a/src/helpers/liquidatePositions.ts
+++ b/src/helpers/liquidatePositions.ts
@@ -1,0 +1,66 @@
+import { IPositionSchema } from "../models/position";
+import colors from 'colors';
+import { PositionManager } from "@mycelium-ethereum/perpetual-swaps-contracts";
+import { liquidations } from "../utils/prometheus";
+
+export const liquidateInBatches = async (positions: IPositionSchema[], positionManager: PositionManager) => {
+    let cursor = 0;
+    const positionsPerTransaction = 50;
+    while (cursor < positions.length) {
+        const batchPositions = positions.slice(cursor, cursor + positionsPerTransaction);
+        if (batchPositions.length === 1) {
+            // If there is only one position, sometimes the batch transaction doesn't work for some reason
+            // so we just send it separately
+            console.log(colors.yellow(`Liquidating ${batchPositions.length} position`));
+            const position = batchPositions[0];
+            const tx = await positionManager.liquidatePosition(
+                position.account,
+                position.collateralToken,
+                position.indexToken,
+                position.isLong,
+                process.env.FEE_RECEIVER_ADDRESS
+            );
+            const receipt = await tx.wait();
+            console.log(colors.green(`Sent!`));
+            console.log(colors.green(`Transaction receipt: ${receipt.transactionHash}`));
+        } else {
+            const accounts = batchPositions.map((position) => position.account);
+            const collateralTokens = batchPositions.map((position) => position.collateralToken);
+            const indexTokens = batchPositions.map((position) => position.indexToken);
+            const isLongs = batchPositions.map((position) => position.isLong);
+
+            console.log(colors.yellow(`Liquidating positions ${cursor} to ${cursor + batchPositions.length}...`));
+            const tx = await positionManager.liquidatePositions(
+                accounts,
+                collateralTokens,
+                indexTokens,
+                isLongs,
+                process.env.FEE_RECEIVER_ADDRESS
+            );
+            const receipt = await tx.wait();
+
+            console.log(colors.green(`Sent!`));
+            console.log(colors.green(`Transaction hash: ${receipt.transactionHash}`));
+        }
+
+        liquidations.inc(batchPositions.length);
+        cursor += positionsPerTransaction;
+    }
+}
+
+export const liquidateOneByOne = async (positions: IPositionSchema[], positionManager: PositionManager) => {
+    for (const position of positions) {
+        console.log(colors.yellow(`Liquidating position ${position.account}`));
+        const tx = await positionManager.liquidatePosition(
+            position.account,
+            position.collateralToken,
+            position.indexToken,
+            position.isLong,
+            process.env.FEE_RECEIVER_ADDRESS
+        );
+        const receipt = await tx.wait();
+        console.log(colors.green(`Sent!`));
+        console.log(colors.green(`Transaction hash: ${receipt.transactionHash}`));
+        liquidations.inc(1);
+    }
+}

--- a/src/models/position.ts
+++ b/src/models/position.ts
@@ -3,24 +3,31 @@ import { Schema, model } from "mongoose";
 export interface IPositionSchema {
     key: string;
     account: string;
-    blockNumber:number;
+    blockNumber: number;
     collateralToken: string;
-    indexToken:string;
+    indexToken: string;
     isLong: boolean;
-    createdAt?: Date;   
+    createdAt?: Date;
+    collateralAmount: string;
+    size: string;
+    averagePrice: string;
+    entryFundingRate: string;
 }
 
 const positionSchema = new Schema<IPositionSchema>({
     key: { type: String, required: true },
     account: { type: String, required: true },
-    blockNumber:{ type: Number, required: false },
+    blockNumber: { type: Number, required: false },
     collateralToken: { type: String, required: true },
-    indexToken:{ type: String, required: true },
+    indexToken: { type: String, required: true },
     isLong: { type: Boolean, required: true },
-    createdAt: { type: Date, default: Date.now },    
+    createdAt: { type: Date, default: Date.now },
+    collateralAmount: { type: String, required: true },
+    size: { type: String, required: true },
+    averagePrice: { type: String, required: true },
+    entryFundingRate: { type: String, required: true },
 });
 
 const Position = model<IPositionSchema>("Position", positionSchema);
 
 export default Position;
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -819,6 +819,11 @@ clone-response@^1.0.2:
   dependencies:
     mimic-response "^1.0.0"
 
+clone@2.x:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
+  integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
 color-convert@^1.9.0:
   version "1.9.3"
   resolved "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz"
@@ -1883,6 +1888,13 @@ negotiator@0.6.2:
   version "0.6.2"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
+
+node-cache@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/node-cache/-/node-cache-5.1.2.tgz#f264dc2ccad0a780e76253a694e9fd0ed19c398d"
+  integrity sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==
+  dependencies:
+    clone "2.x"
 
 node-cron@3.0.0:
   version "3.0.0"


### PR DESCRIPTION
## Motivation
The previous iteration of the liquidator with call the RPC endpoint many times on each iteration, which would result in errors due to high node usage.  This iteration does more calls on the initial sync of the state, but then can do a screening locally to weed out obviously not liquidatible positions.

